### PR TITLE
Upgraded dependencies + works on arm64

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,12 +1,12 @@
 plugins {
-    id("com.google.protobuf") version "0.8.15" apply false
-    kotlin("jvm") version "1.4.32" apply false
+    id("com.google.protobuf") version "0.8.18" apply false
+    kotlin("jvm") version "1.7.0" apply false
 }
 
 // todo: move to subprojects, but how?
-ext["grpcVersion"] = "1.37.0"
-ext["grpcKotlinVersion"] = "1.1.0" // CURRENT_GRPC_KOTLIN_VERSION
-ext["protobufVersion"] = "3.15.8"
+ext["grpcVersion"] = "1.46.0"
+ext["grpcKotlinVersion"] = "1.2.1" // CURRENT_GRPC_KOTLIN_VERSION
+ext["protobufVersion"] = "3.20.1"
 
 allprojects {
     repositories {

--- a/stub/build.gradle.kts
+++ b/stub/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     api("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3")
 
     api("io.grpc:grpc-protobuf:${rootProject.ext["grpcVersion"]}")
+    api("io.grpc:grpc-stub:${rootProject.ext["grpcVersion"]}")
     api("com.google.protobuf:protobuf-java-util:${rootProject.ext["protobufVersion"]}")
     api("io.grpc:grpc-kotlin-stub:${rootProject.ext["grpcKotlinVersion"]}")
 }


### PR DESCRIPTION
protobuf added support for arm64 in version 3.20.1. See https://github.com/protocolbuffers/protobuf/issues/8062

Also upgraded all other dependencies and plugins.

The project is now working on arm64.